### PR TITLE
current_user を導入して記事とログインユーザーを紐付け

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,13 +1,29 @@
 module Api::V1
-  class ArticlesController < BaseApiController
+  class ArticlesController < Api::V1::BaseApiController
+
     def index
       articles = Article.order(updated_at: "DESC")
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      articles = Article.find(params[:id])
-      render json: articles, erializer: Api::V1::ArticlePreviewSerializer
+      article = Article.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      # binding.pry
+      # article = Article.new(article_params)
+      # article.user_id = current_user.id
+      article = current_user.articles.create!(article_params)
+
+      # article.save!
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,7 @@
 class Api::V1::BaseApiController < ApplicationController
+
+  def current_user
+    @current_user ||= User.first
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,5 +47,6 @@ module WonderfulEditor
 
     config.api_only = true
     config.middleware.use ActionDispatch::Flash
+
   end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -14,28 +14,30 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(res["data"][0].keys).to eq ["id", "type", "attributes", "relationships"]
     end
 
-    # fit "記事の本文が含まれている" do
-    #   binding.pry
-    #   expext(article).to be_invalid
 
-    # end
   end
 
   describe "Get api/v1/articles/:id " do
     subject { get(api_v1_article_path(article_id)) }
+    let(:article_id) { article.id }
+    let(:article) { create(:article) }
 
-    context "指定した id の記事が存在する場合" do
-      let(:article_id) { article.id }
-      let(:article) { create(:article) }
+    context "指定した id の記事のデータが存在する場合" do
+
+      # let(:article_id) { article.id }
+      # let(:article) { create(:article) }
+
 
       it "記事の詳細を取得できる" do
         subject
+
         res = JSON.parse(response.body)
 
+        # expect(res["data"]["id"]).to eq article.id
+        expect(res["data"]["attributes"]["title"]).to eq article.title
+        expect(res["data"]["attributes"]["body"]).to eq article.body
+        expect(res["data"]["attributes"]["updated-at"]).to be_present
         expect(response).to have_http_status(:ok)
-        expect(res["id"]).to eq article.id
-        expect(res["title"]).to eq article.title
-        expect(res["body"]).to eq article.body
       end
     end
 
@@ -46,5 +48,35 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
+  end
+
+  describe "POST /api/v1/articles" do
+    subject { post(api_v1_articles_path, params: params)}
+
+    let(:params) { { article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+
+    before{ allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    context "適切なパラメーターが送信された時" do
+
+
+      it "ユーザーのレコードが作成される" do
+
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["data"]["attributes"]["title"]).to eq params[:article][:title]
+        expect(res["data"]["attributes"]["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "不適切なパラメーターが送信された時" do
+      let(:params) { attributes_for(:article) }
+      fit "エラーする" do
+        expect { subject }.to raise_error(ActionController::ParameterMissing)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## 概要
- api/v1/article.controller に current_user を定義
- Rspec の current_user を stab化 