### PR TITLE
DELETE メソッドの実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -21,11 +21,16 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def destroy
+      article = current_user.articles.find(params[:id])
+      article.destroy!
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
     private
 
       def article_params
         params.require(:article).permit(:title, :body)
       end
-
   end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -60,3 +60,9 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+
+RSpec/LetSetup:
+  Enabled: false


### PR DESCRIPTION
## 概要
- タイトルの通り
- article contorller に destroy メソッドの実装
- rubocop で allow_any_instance_of を無視するコメントの実装