### PR TITLE
下書き機能のテストの実装に伴い、既存API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ module Api::V1
     before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
-      articles = Article.order(updated_at: "DESC")
+      articles = Article.published.order(updated_at: "DESC")
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
@@ -32,7 +32,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,5 +6,5 @@ class Article < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
 
-  enum status: { draft: 0, published: 1 }
+  enum status: { draft: "draft", published: "published" }
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/db/migrate/20220220125704_add_status_to_articles.rb
+++ b/db/migrate/20220220125704_add_status_to_articles.rb
@@ -1,5 +1,5 @@
 class AddStatusToArticles < ActiveRecord::Migration[6.0]
   def change
-    add_column :articles, :status, :integer, default: 0
+    add_column :articles, :status, :string, default: "draft"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_024712) do
+ActiveRecord::Schema.define(version: 2022_02_20_125704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2022_02_14_024712) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "status", default: 0
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,4 +4,12 @@ FactoryBot.define do
     body { Faker::Lorem.sentence }
     user
   end
+
+  trait :draft do
+    status { :draft }
+  end
+
+  trait :published do
+    status { :published }
+  end
 end


### PR DESCRIPTION
## 概要
- 記事取得を公開済みの記事のみ取得するよう実装
- 記事作成時に公開、非公開で作成できるよう実装
- それに伴い、article_controller を修正