### PR TITLE
下書き機能の一覧・詳細のAPIの実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,15 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,19 @@
 Rails.application.routes.draw do
   root to: "home#index"
 
-  # reload 対策
-  get "sign_up", to: "home#index"
-  get "sign_in", to: "home#index"
-  get "articles/new", to: "home#index"
-  get "articles/:id", to: "home#index"
+  # get "sign_up", to: "home#index"
+  # get "sign_in", to: "home#index"
+  # get "articles/new", to: "home#index"
+  # get "articles/:id", to: "home#index"
 
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Article::Drafts", type: :request do
+  let(:current_user) { create(:user) }
+  let(:headers) { current_user.create_new_auth_token }
+
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    context "自分の書いた下書きの記事が存在するとき" do
+      let!(:article) { create(:article, :draft, user: current_user) }
+
+      it " 下書きの記事の一覧を取得する事ができる " do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["data"].length).to eq(1)
+        expect(response).to have_http_status(:ok)
+        expect(res["data"][0].keys).to eq ["id", "type", "attributes", "relationships"]
+        expect(article).to be_draft
+      end
+    end
+  end
+
+  describe "GET /api/v1/articles/draft/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    context "指定した id の記事が存在して" do
+      let(:article_id) { article.id }
+
+      context "対象の記事が自分が書いた下書きのとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+
+        it "記事の詳細を取得できる" do
+          subject
+          res = JSON.parse(response.body)
+          expect(res["data"]["id"]).to eq article.id.to_s
+          expect(res["data"]["attributes"]["title"]).to eq article.title
+          expect(res["data"]["attributes"]["body"]).to eq article.body
+          expect(res["data"]["attributes"]["updated-at"]).to be_present
+          expect(res["data"]["attributes"]["status"]).to eq article.status
+          expect(response).to have_http_status(:ok)
+        end
+      end
+
+      context "対象の記事が他人が書いた下書きのとき" do
+        let(:article) { create(:article, :draft) }
+        it "エラーする" do
+          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- 上記の API の実装
- api/v1/articles/drafts_controller の作成
- api/v1/articles/drafts_spec の作成
- routing の設定